### PR TITLE
Add unified notification center and admin broadcast tools

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { Toaster } from 'react-hot-toast';
 import { AuthProvider } from './context/AuthContext';
 import { ToastProvider } from './context/ToastContext';
+import { NotificationProvider } from './context/NotificationContext';
 import { courseStore } from './store/courseStore';
 import { LoadingSpinner } from './components/LoadingComponents';
 import { ErrorBoundary } from './components/ErrorHandling';
@@ -25,6 +26,7 @@ const ResourcePage = lazy(() => import('./pages/ResourcePage'));
 const TestimonialsPage = lazy(() => import('./pages/TestimonialsPage'));
 const ContactPage = lazy(() => import('./pages/ContactPage'));
 const ClientPortalPage = lazy(() => import('./pages/ClientPortalPage'));
+const NotificationsHubPage = lazy(() => import('./pages/NotificationsHubPage'));
 
 // Lazy load LMS components
 const LMSCourses = lazy(() => import('./pages/LMS/LMSCourses'));
@@ -64,6 +66,7 @@ const AdminUserProfile = lazy(() => import('./pages/Admin/AdminUserProfile'));
 const AdminOrgProfile = lazy(() => import('./pages/Admin/AdminOrgProfile'));
 const AdminResourceSender = lazy(() => import('./pages/Admin/AdminResourceSender'));
 const AdminPerformanceDashboard = lazy(() => import('./pages/Admin/AdminPerformanceDashboard'));
+const AdminBroadcastCenter = lazy(() => import('./pages/Admin/AdminBroadcastCenter'));
 
 // Lazy load additional components
 const AIBot = lazy(() => import('./components/AIBot/AIBot'));
@@ -85,115 +88,119 @@ function App() {
     <ErrorBoundary>
       <ToastProvider>
         <AuthProvider>
-          <Router>
-            <div className="min-h-screen flex flex-col bg-white">
-            <Header />
-            <DemoModeBanner />
-            <main className="flex-grow">
-              <Suspense fallback={<LoadingSpinner size="lg" className="py-20" text="Loading..." />}>
-                <Routes>
-              <Route path="/" element={<HomePage />} />
-              <Route path="/about" element={<AboutPage />} />
-              <Route path="/services" element={<ServicesPage />} />
-              <Route path="/resources" element={<ResourcePage />} />
-              <Route path="/testimonials" element={<TestimonialsPage />} />
-              <Route path="/contact" element={<ContactPage />} />
-              <Route path="/client-portal" element={<ClientPortalPage />} />
-              <Route path="/client-portal/org/:orgId/*" element={
-                <OrgWorkspaceLayout />
-              }>
-                <Route path="strategic-plans" element={<StrategicPlansPage />} />
-                <Route path="session-notes" element={<SessionNotesPage />} />
-                <Route path="action-tracker" element={<ActionTrackerPage />} />
-                <Route path="documents" element={<DocumentsPage />} />
-                <Route path="" element={<StrategicPlansPage />} />
-              </Route>
-              <Route path="/lms/login" element={<LMSLogin />} />
-              <Route path="/lms" element={<Navigate to="/lms/dashboard" replace />} />
-              <Route path="/lms/*" element={
-                <LMSLayout>
-                  <Routes>
-                    <Route path="dashboard" element={<LearnerDashboard />} />
-                    <Route path="courses" element={<LMSCourses />} />
-                    <Route path="course/:courseId" element={<CoursePlayer />} />
-                    <Route path="course/:courseId/lesson/:lessonId" element={<CoursePlayer />} />
-                    <Route path="module/:moduleId" element={<LMSModule />} />
-                    <Route path="downloads" element={<LMSDownloads />} />
-                    <Route path="feedback" element={<LMSFeedback />} />
-                    <Route path="contact" element={<LMSContact />} />
-                    <Route path="settings" element={<LMSSettings />} />
-                    <Route path="certificates" element={<LMSCertificates />} />
-                    <Route path="progress" element={<LMSProgress />} />
-                    <Route path="help" element={<LMSHelp />} />
-                  </Routes>
-                </LMSLayout>
-              } />
-              <Route path="/admin/login" element={<AdminLogin />} />
-              <Route path="/admin" element={<Navigate to="/admin/dashboard" replace />} />
-              <Route path="/admin/*" element={
-                <AdminLayout>
-                  <Routes>
-                    <Route path="dashboard" element={<AdminDashboard />} />
-                    <Route path="users" element={<AdminUsers />} />
-                    <Route path="users/:userId" element={<AdminUserProfile />} />
-                    <Route path="organizations" element={<AdminOrganizations />} />
-                    <Route path="organizations/new" element={<AdminOrganizationNew />} />
-                    <Route path="organizations/:id" element={<OrganizationDetails />} />
-                    <Route path="org-profiles/:orgProfileId" element={<AdminOrgProfile />} />
-                    <Route path="send-resource" element={<AdminResourceSender />} />
-                    <Route path="courses" element={<AdminCourses />} />
-                    <Route path="reports" element={<AdminReports />} />
-                    <Route path="analytics" element={<AdminAnalytics />} />
-                    <Route path="performance" element={<AdminPerformanceDashboard />} />
-                    <Route path="certificates" element={<AdminCertificates />} />
-                    <Route path="integrations" element={<AdminIntegrations />} />
-                    <Route path="integrations/:integrationId" element={<AdminIntegrationConfig />} />
-                    <Route path="surveys" element={<AdminSurveys />} />
-                    <Route path="surveys/builder" element={<AdminSurveyBuilder />} />
-                    <Route path="surveys/builder/:surveyId" element={<AdminSurveyBuilder />} />
-                    <Route path="surveys/:surveyId/analytics" element={<AdminSurveyAnalytics />} />
-                    <Route path="surveys/:surveyId/preview" element={<AdminSurveyBuilder />} />
-                    <Route path="course-builder/:courseId" element={<AdvancedCourseBuilder />} />
-                    <Route path="courses/:courseId/details" element={<AdminCourseDetail />} />
-                    <Route path="documents" element={<AdminDocuments />} />
-                    <Route path="settings" element={<AdminSettings />} />
-                  </Routes>
-                </AdminLayout>
-              } />
-                </Routes>
-              </Suspense>
-            </main>
-            <Footer />
-            <AIBot />
-            <ConnectionDiagnostic />
-            <TroubleshootingGuide />
-          </div>
-          <Toaster 
-            position="top-right"
-            toastOptions={{
-              duration: 4000,
-              style: {
-                background: '#363636',
-                color: '#fff',
-              },
-              success: {
-                duration: 3000,
-                iconTheme: {
-                  primary: '#10b981',
-                  secondary: '#fff',
-                },
-              },
-              error: {
-                duration: 5000,
-                iconTheme: {
-                  primary: '#ef4444',
-                  secondary: '#fff',
-                },
-              },
-            }}
-          />
-        </Router>
-      </AuthProvider>
+          <NotificationProvider>
+            <Router>
+              <div className="min-h-screen flex flex-col bg-white">
+                <Header />
+                <DemoModeBanner />
+                <main className="flex-grow">
+                  <Suspense fallback={<LoadingSpinner size="lg" className="py-20" text="Loading..." />}>
+                    <Routes>
+                      <Route path="/" element={<HomePage />} />
+                      <Route path="/about" element={<AboutPage />} />
+                      <Route path="/services" element={<ServicesPage />} />
+                      <Route path="/resources" element={<ResourcePage />} />
+                      <Route path="/testimonials" element={<TestimonialsPage />} />
+                      <Route path="/contact" element={<ContactPage />} />
+                      <Route path="/client-portal" element={<ClientPortalPage />} />
+                      <Route path="/notifications" element={<NotificationsHubPage />} />
+                      <Route path="/client-portal/org/:orgId/*" element={
+                        <OrgWorkspaceLayout />
+                      }>
+                        <Route path="strategic-plans" element={<StrategicPlansPage />} />
+                        <Route path="session-notes" element={<SessionNotesPage />} />
+                        <Route path="action-tracker" element={<ActionTrackerPage />} />
+                        <Route path="documents" element={<DocumentsPage />} />
+                        <Route path="" element={<StrategicPlansPage />} />
+                      </Route>
+                      <Route path="/lms/login" element={<LMSLogin />} />
+                      <Route path="/lms" element={<Navigate to="/lms/dashboard" replace />} />
+                      <Route path="/lms/*" element={
+                        <LMSLayout>
+                          <Routes>
+                            <Route path="dashboard" element={<LearnerDashboard />} />
+                            <Route path="courses" element={<LMSCourses />} />
+                            <Route path="course/:courseId" element={<CoursePlayer />} />
+                            <Route path="course/:courseId/lesson/:lessonId" element={<CoursePlayer />} />
+                            <Route path="module/:moduleId" element={<LMSModule />} />
+                            <Route path="downloads" element={<LMSDownloads />} />
+                            <Route path="feedback" element={<LMSFeedback />} />
+                            <Route path="contact" element={<LMSContact />} />
+                            <Route path="settings" element={<LMSSettings />} />
+                            <Route path="certificates" element={<LMSCertificates />} />
+                            <Route path="progress" element={<LMSProgress />} />
+                            <Route path="help" element={<LMSHelp />} />
+                          </Routes>
+                        </LMSLayout>
+                      } />
+                      <Route path="/admin/login" element={<AdminLogin />} />
+                      <Route path="/admin" element={<Navigate to="/admin/dashboard" replace />} />
+                      <Route path="/admin/*" element={
+                        <AdminLayout>
+                          <Routes>
+                            <Route path="dashboard" element={<AdminDashboard />} />
+                            <Route path="users" element={<AdminUsers />} />
+                            <Route path="users/:userId" element={<AdminUserProfile />} />
+                            <Route path="organizations" element={<AdminOrganizations />} />
+                            <Route path="organizations/new" element={<AdminOrganizationNew />} />
+                            <Route path="organizations/:id" element={<OrganizationDetails />} />
+                            <Route path="org-profiles/:orgProfileId" element={<AdminOrgProfile />} />
+                            <Route path="send-resource" element={<AdminResourceSender />} />
+                            <Route path="courses" element={<AdminCourses />} />
+                            <Route path="reports" element={<AdminReports />} />
+                            <Route path="analytics" element={<AdminAnalytics />} />
+                            <Route path="performance" element={<AdminPerformanceDashboard />} />
+                            <Route path="certificates" element={<AdminCertificates />} />
+                            <Route path="integrations" element={<AdminIntegrations />} />
+                            <Route path="integrations/:integrationId" element={<AdminIntegrationConfig />} />
+                            <Route path="surveys" element={<AdminSurveys />} />
+                            <Route path="surveys/builder" element={<AdminSurveyBuilder />} />
+                            <Route path="surveys/builder/:surveyId" element={<AdminSurveyBuilder />} />
+                            <Route path="surveys/:surveyId/analytics" element={<AdminSurveyAnalytics />} />
+                            <Route path="surveys/:surveyId/preview" element={<AdminSurveyBuilder />} />
+                            <Route path="course-builder/:courseId" element={<AdvancedCourseBuilder />} />
+                            <Route path="courses/:courseId/details" element={<AdminCourseDetail />} />
+                            <Route path="documents" element={<AdminDocuments />} />
+                            <Route path="settings" element={<AdminSettings />} />
+                            <Route path="notifications" element={<AdminBroadcastCenter />} />
+                          </Routes>
+                        </AdminLayout>
+                      } />
+                    </Routes>
+                  </Suspense>
+                </main>
+                <Footer />
+                <AIBot />
+                <ConnectionDiagnostic />
+                <TroubleshootingGuide />
+              </div>
+              <Toaster
+                position="top-right"
+                toastOptions={{
+                  duration: 4000,
+                  style: {
+                    background: '#363636',
+                    color: '#fff',
+                  },
+                  success: {
+                    duration: 3000,
+                    iconTheme: {
+                      primary: '#10b981',
+                      secondary: '#fff',
+                    },
+                  },
+                  error: {
+                    duration: 5000,
+                    iconTheme: {
+                      primary: '#ef4444',
+                      secondary: '#fff',
+                    },
+                  },
+                }}
+              />
+            </Router>
+          </NotificationProvider>
+        </AuthProvider>
       </ToastProvider>
     </ErrorBoundary>
   );

--- a/src/components/Admin/AdminLayout.tsx
+++ b/src/components/Admin/AdminLayout.tsx
@@ -4,18 +4,17 @@ import { Link, useLocation, useNavigate, Outlet } from 'react-router-dom';
 import { ErrorBoundary } from '../ErrorHandling';
 import AdminErrorBoundary from '../ErrorBoundary/AdminErrorBoundary';
 import { useAuth } from '../../context/AuthContext';
-import { 
-  LayoutDashboard, 
-  Users, 
-  Building2, 
-  BookOpen, 
-  BarChart3, 
-  Settings, 
-  LogOut, 
-  Menu, 
+import {
+  LayoutDashboard,
+  Users,
+  Building2,
+  BookOpen,
+  BarChart3,
+  Settings,
+  LogOut,
+  Menu,
   X,
   Shield,
-  Bell,
   Search,
   Plus,
   TrendingUp,
@@ -26,6 +25,8 @@ import {
   Clock,
   Target
 } from 'lucide-react';
+import NotificationBell from '../notifications/NotificationBell';
+import NotificationBannerHost from '../notifications/NotificationBannerHost';
 
 interface AdminLayoutProps {
   children?: ReactNode;
@@ -38,6 +39,7 @@ const navigation = [
   { name: 'Courses', href: '/admin/courses', icon: BookOpen },
   { name: 'Analytics', href: '/admin/analytics', icon: BarChart3 },
   { name: 'Performance', href: '/admin/performance', icon: TrendingUp },
+  { name: 'Notifications', href: '/admin/notifications', icon: Target },
   { name: 'Settings', href: '/admin/settings', icon: Settings },
 ];
 
@@ -366,13 +368,10 @@ const AdminLayout: FC<AdminLayoutProps> = ({ children }) => {
                 >
                   <Plus className="h-4 w-4" />
                 </button>
-                <button className="relative p-2 text-gray-600 hover:text-gray-900">
-                  <Bell className="h-5 w-5" />
-                  <span className="absolute top-0 right-0 block h-2 w-2 rounded-full bg-red-400"></span>
-                </button>
+                <NotificationBell variant="admin" />
                 <div className="flex items-center space-x-2">
-                  <img 
-                    src="https://images.pexels.com/photos/3184416/pexels-photo-3184416.jpeg?auto=compress&cs=tinysrgb&w=100" 
+                  <img
+                    src="https://images.pexels.com/photos/3184416/pexels-photo-3184416.jpeg?auto=compress&cs=tinysrgb&w=100"
                     alt={user?.name || 'Admin'}
                     className="w-8 h-8 rounded-full object-cover"
                   />
@@ -385,6 +384,7 @@ const AdminLayout: FC<AdminLayoutProps> = ({ children }) => {
           {/* Page content */}
           <main className="flex-1 bg-gray-50 min-h-0">
             <div className="p-6 h-full">
+              <NotificationBannerHost />
               <AdminErrorBoundary showDetails={true}>
                 <ErrorBoundary>
                   {children ? children : <Outlet />}

--- a/src/components/LMS/EnhancedLMSLayout.tsx
+++ b/src/components/LMS/EnhancedLMSLayout.tsx
@@ -3,7 +3,8 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import ClientErrorBoundary from '../ClientErrorBoundary';
 import ProgressSyncStatus from '../ProgressSyncStatus';
-import RealtimeNotifications from '../RealtimeNotifications';
+import NotificationBell from '../notifications/NotificationBell';
+import NotificationBannerHost from '../notifications/NotificationBannerHost';
 import { useEnhancedCourseProgress } from '../../hooks/useEnhancedCourseProgress';
 import { 
   LayoutDashboard, 
@@ -266,10 +267,7 @@ const EnhancedLMSLayout: React.FC<EnhancedLMSLayoutProps> = ({ children }) => {
                   />
 
                   {/* Real-time Notifications */}
-                  <RealtimeNotifications 
-                    userId={user?.id || 'demo-user'}
-                    enabled={true}
-                  />
+                  <NotificationBell variant="client" />
 
                   {/* User Profile Menu */}
                   <div className="relative">
@@ -296,7 +294,10 @@ const EnhancedLMSLayout: React.FC<EnhancedLMSLayoutProps> = ({ children }) => {
 
           {/* Page Content */}
           <main className="flex-1 overflow-auto">
-            {children}
+            <NotificationBannerHost />
+            <div className="px-6 py-4">
+              {children}
+            </div>
           </main>
         </div>
       </div>

--- a/src/components/LMS/LMSLayout.tsx
+++ b/src/components/LMS/LMSLayout.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
-import { 
-  LayoutDashboard, 
-  BookOpen, 
+import {
+  LayoutDashboard,
+  BookOpen,
   Download, 
   MessageSquare, 
   Phone, 
@@ -16,6 +16,8 @@ import {
   Settings,
   HelpCircle
 } from 'lucide-react';
+import NotificationBell from '../notifications/NotificationBell';
+import NotificationBannerHost from '../notifications/NotificationBannerHost';
 
 interface LMSLayoutProps {
   children: React.ReactNode;
@@ -164,12 +166,19 @@ const LMSLayout: React.FC<LMSLayoutProps> = ({ children }) => {
               </div>
               <span className="font-bold text-gray-900">The Huddle Co.</span>
             </div>
+            <NotificationBell variant="client" />
           </div>
         </div>
 
         {/* Page content */}
         <main className="flex-1">
-          {children}
+          <div className="hidden items-center justify-end border-b border-gray-200 bg-white px-6 py-4 shadow-sm lg:flex">
+            <NotificationBell variant="client" />
+          </div>
+          <NotificationBannerHost />
+          <div className="px-4 py-4 lg:px-8">
+            {children}
+          </div>
         </main>
       </div>
     </div>

--- a/src/components/notifications/NotificationBannerHost.tsx
+++ b/src/components/notifications/NotificationBannerHost.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { X, Sparkles, AlertTriangle } from 'lucide-react';
+import { cn } from '../../utils/cn';
+import { useNotificationCenter } from '../../context/NotificationContext';
+import type { NotificationRecord } from '../../types/notifications';
+
+interface NotificationBannerHostProps {
+  limit?: number;
+  autoDismissMs?: number;
+}
+
+const shouldShowBanner = (notification: NotificationRecord) => {
+  if (notification.archived) return false;
+  if (notification.isRead && notification.priority !== 'urgent') return false;
+  if (notification.expiresAt) {
+    const expires = new Date(notification.expiresAt).getTime();
+    if (expires < Date.now()) return false;
+  }
+  return notification.priority === 'high' || notification.priority === 'urgent' || notification.category === 'celebration';
+};
+
+const NotificationBannerHost = ({ limit = 2, autoDismissMs = 1000 * 12 }: NotificationBannerHostProps) => {
+  const { notifications, markAsRead } = useNotificationCenter();
+  const [dismissed, setDismissed] = useState<Record<string, boolean>>({});
+
+  const banners = useMemo(
+    () =>
+      notifications
+        .filter(shouldShowBanner)
+        .filter((notification) => !dismissed[notification.id])
+        .sort(
+          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        )
+        .slice(0, limit),
+    [notifications, dismissed, limit]
+  );
+
+  useEffect(() => {
+    if (banners.length === 0) return;
+    const timers = banners.map((notification) =>
+      setTimeout(() => {
+        setDismissed((prev) => ({ ...prev, [notification.id]: true }));
+        if (notification.priority !== 'urgent') {
+          markAsRead(notification.id).catch(() => {});
+        }
+      }, autoDismissMs)
+    );
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+    };
+  }, [banners, autoDismissMs, markAsRead]);
+
+  if (banners.length === 0) return null;
+
+  return (
+    <div className="space-y-3 px-4 py-2">
+      {banners.map((notification, index) => {
+        const isCelebration = notification.category === 'celebration';
+        const background = isCelebration ? 'bg-gradient-to-r from-[#FF8895] to-[#D72638]' : 'bg-gradient-to-r from-[#3A7FFF] to-[#2D9B66]';
+        return (
+          <div
+            key={notification.id}
+            className={cn(
+              'relative overflow-hidden rounded-2xl text-white shadow-lg transition-all duration-300 ease-in-out',
+              background,
+              'focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-white'
+            )}
+            style={{
+              animation: `banner-slide-in 0.3s ease-in-out`,
+            }}
+          >
+            <div className="flex items-center justify-between gap-4 px-5 py-4">
+              <div className="flex flex-1 items-start gap-3">
+                <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-full bg-white/20">
+                  {isCelebration ? (
+                    <Sparkles className="h-5 w-5" aria-hidden="true" />
+                  ) : (
+                    <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+                  )}
+                </div>
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold uppercase tracking-wide" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+                    {notification.title}
+                  </p>
+                  <p className="text-sm" style={{ fontFamily: 'Lato, sans-serif' }}>
+                    {notification.message}
+                  </p>
+                  {notification.link && (
+                    <Link
+                      to={notification.link}
+                      onClick={() => markAsRead(notification.id)}
+                      className="inline-flex items-center rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white transition-colors hover:bg-white/30"
+                    >
+                      {notification.actionLabel ?? 'View details'}
+                    </Link>
+                  )}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setDismissed((prev) => ({ ...prev, [notification.id]: true }))}
+                className="rounded-full bg-white/10 p-2 text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white"
+                aria-label={`Dismiss notification ${notification.title}`}
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+            <div className="absolute inset-x-0 bottom-0 h-1 bg-white/30">
+              <div
+                className="h-full bg-white"
+                style={{
+                  animation: `banner-progress ${autoDismissMs}ms linear forwards`,
+                  animationDelay: `${index * 50}ms`,
+                }}
+              />
+            </div>
+          </div>
+        );
+      })}
+      <style>
+        {`@keyframes banner-slide-in {
+            from { transform: translateY(-10px); opacity: 0; }
+            to { transform: translateY(0); opacity: 1; }
+          }
+          @keyframes banner-progress {
+            from { width: 100%; }
+            to { width: 0%; }
+          }`}
+      </style>
+    </div>
+  );
+};
+
+export default NotificationBannerHost;

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Bell,
+  CheckCircle2,
+  ChevronRight,
+  Clock3,
+  Megaphone,
+  GraduationCap,
+  Sparkles,
+  ClipboardList,
+  ShieldAlert,
+  Inbox,
+} from 'lucide-react';
+import { cn } from '../../utils/cn';
+import { useNotificationCenter } from '../../context/NotificationContext';
+import type { NotificationRecord } from '../../types/notifications';
+
+interface NotificationBellProps {
+  maxPreview?: number;
+  variant?: 'admin' | 'client';
+  className?: string;
+}
+
+const categoryIcon = (notification: NotificationRecord) => {
+  switch (notification.type) {
+    case 'assignment':
+      return <GraduationCap className="h-4 w-4 text-[#3A7FFF]" aria-hidden="true" />;
+    case 'survey_reminder':
+      return <ClipboardList className="h-4 w-4 text-[#2D9B66]" aria-hidden="true" />;
+    case 'completion':
+      return <Sparkles className="h-4 w-4 text-[#FF8895]" aria-hidden="true" />;
+    case 'broadcast':
+      return <Megaphone className="h-4 w-4 text-[#D72638]" aria-hidden="true" />;
+    case 'system':
+      return <ShieldAlert className="h-4 w-4 text-[#3A7FFF]" aria-hidden="true" />;
+    default:
+      return <Bell className="h-4 w-4 text-[#3A7FFF]" aria-hidden="true" />;
+  }
+};
+
+const priorityChip = (notification: NotificationRecord) => {
+  const base =
+    'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold tracking-wide';
+
+  switch (notification.priority) {
+    case 'urgent':
+      return <span className={`${base} bg-[#D72638]/10 text-[#D72638]`}>Urgent</span>;
+    case 'high':
+      return <span className={`${base} bg-[#FF8895]/20 text-[#D72638]`}>High</span>;
+    case 'medium':
+      return <span className={`${base} bg-[#3A7FFF]/10 text-[#3A7FFF]`}>Medium</span>;
+    default:
+      return <span className={`${base} bg-slate-200 text-slate-600`}>Info</span>;
+  }
+};
+
+const formatRelativeTime = (isoDate: string) => {
+  const created = new Date(isoDate);
+  const now = new Date();
+  const diffMs = now.getTime() - created.getTime();
+  const diffMinutes = Math.round(diffMs / 60000);
+  if (diffMinutes < 1) return 'Just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.round(diffHours / 24);
+  return `${diffDays}d ago`;
+};
+
+const NotificationBell = ({
+  maxPreview = 5,
+  variant = 'client',
+  className,
+}: NotificationBellProps) => {
+  const {
+    notifications,
+    unreadCount,
+    markAsRead,
+    recordClick,
+    markAllAsRead,
+  } = useNotificationCenter();
+  const [open, setOpen] = useState(false);
+  const bellRef = useRef<HTMLDivElement>(null);
+
+  const latestNotifications = useMemo(
+    () =>
+      notifications
+        .filter((item) => !item.archived)
+        .sort(
+          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        )
+        .slice(0, maxPreview),
+    [notifications, maxPreview]
+  );
+
+  useEffect(() => {
+    const handler = (event: MouseEvent) => {
+      if (bellRef.current && !bellRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    if (open) {
+      document.addEventListener('mousedown', handler);
+    }
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const handleAction = async (notification: NotificationRecord) => {
+    await markAsRead(notification.id);
+    recordClick(notification.id);
+    setOpen(false);
+  };
+
+  const containerClasses = cn('relative', className);
+  const badgeColor = variant === 'admin' ? '#D72638' : '#FF8895';
+
+  return (
+    <div className={containerClasses} ref={bellRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className={cn(
+          'relative rounded-full p-2 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+          variant === 'admin'
+            ? 'text-slate-600 hover:text-[#D72638] focus-visible:ring-[#D72638]'
+            : 'text-slate-600 hover:text-[#3A7FFF] focus-visible:ring-[#3A7FFF]'
+        )}
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-label={unreadCount ? `${unreadCount} unread notifications` : 'Notifications'}
+      >
+        <Bell className="h-6 w-6" aria-hidden="true" />
+        {unreadCount > 0 && (
+          <span
+            className="absolute -top-1 -right-1 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full px-1 text-xs font-semibold text-white shadow-lg"
+            style={{ backgroundColor: badgeColor }}
+          >
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      <div
+        className={cn(
+          'absolute right-0 mt-3 w-96 max-w-sm origin-top-right transform rounded-2xl border border-slate-200 bg-white shadow-2xl transition-all duration-300 ease-in-out dark:border-slate-700 dark:bg-slate-900',
+          open
+            ? 'scale-100 opacity-100'
+            : 'pointer-events-none scale-95 opacity-0'
+        )}
+      >
+        <div className="flex items-center justify-between border-b border-slate-100 px-5 py-3 dark:border-slate-700">
+          <div>
+            <p className="text-sm font-semibold tracking-wide text-slate-900 dark:text-white" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+              Notification Center
+            </p>
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Stay in sync with assignments, surveys, and updates.
+            </p>
+          </div>
+          {unreadCount > 0 && (
+            <button
+              onClick={() => markAllAsRead()}
+              className="text-xs font-semibold text-[#3A7FFF] transition-colors hover:text-[#2D9B66] focus:outline-none"
+            >
+              Mark all read
+            </button>
+          )}
+        </div>
+
+        <div className="max-h-80 overflow-y-auto px-2 py-3">
+          {latestNotifications.length === 0 ? (
+            <div className="flex flex-col items-center justify-center space-y-3 rounded-xl bg-slate-50 px-6 py-8 text-center dark:bg-slate-800">
+              <Inbox className="h-10 w-10 text-slate-300" aria-hidden="true" />
+              <div>
+                <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+                  You’re all caught up
+                </p>
+                <p className="text-xs text-slate-500">
+                  New notifications will appear here in real time.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {latestNotifications.map((notification) => (
+                <li
+                  key={notification.id}
+                  className={cn(
+                    'rounded-xl border border-transparent bg-white p-3 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-[#3A7FFF]/30 hover:shadow-lg dark:bg-slate-800',
+                    !notification.isRead && 'bg-[#3A7FFF]/5'
+                  )}
+                >
+                  <button
+                    type="button"
+                    onClick={() => handleAction(notification)}
+                    className="flex w-full items-start justify-between text-left"
+                  >
+                    <div className="flex flex-1 items-start space-x-3">
+                      <div className="mt-1 flex h-9 w-9 items-center justify-center rounded-full bg-slate-100 dark:bg-slate-700">
+                        {categoryIcon(notification)}
+                      </div>
+                      <div className="flex-1 space-y-1">
+                        <div className="flex items-center justify-between">
+                          <p className="text-sm font-semibold text-slate-900 dark:text-white" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+                            {notification.title}
+                          </p>
+                          {priorityChip(notification)}
+                        </div>
+                        <p className="text-sm text-slate-600 dark:text-slate-300" style={{ fontFamily: 'Lato, sans-serif' }}>
+                          {notification.message}
+                        </p>
+                        <div className="flex items-center space-x-3 text-xs text-slate-500">
+                          <span className="inline-flex items-center space-x-1">
+                            <Clock3 className="h-3 w-3" aria-hidden="true" />
+                            <span>{formatRelativeTime(notification.createdAt)}</span>
+                          </span>
+                          {notification.link && (
+                            <span className="inline-flex items-center space-x-1 text-[#3A7FFF]">
+                              <ChevronRight className="h-3 w-3" aria-hidden="true" />
+                              <span>Open</span>
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    {!notification.isRead && (
+                      <CheckCircle2 className="ml-3 h-5 w-5 flex-shrink-0 text-[#2D9B66]" aria-hidden="true" />
+                    )}
+                  </button>
+                  {notification.link && (
+                    <Link
+                      to={notification.link}
+                      onClick={() => handleAction(notification)}
+                      className="mt-3 inline-flex items-center space-x-1 rounded-lg bg-[#3A7FFF]/10 px-3 py-1 text-xs font-semibold text-[#3A7FFF] transition-colors hover:bg-[#3A7FFF]/20"
+                    >
+                      <span>{notification.actionLabel ?? 'View details'}</span>
+                      <ChevronRight className="h-3 w-3" aria-hidden="true" />
+                    </Link>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between rounded-b-2xl bg-slate-50 px-5 py-3 dark:bg-slate-800">
+          <div className="flex items-center space-x-2 text-xs text-slate-500">
+            <Megaphone className="h-4 w-4 text-[#FF8895]" aria-hidden="true" />
+            <span>
+              {unreadCount} unread • {notifications.length} total
+            </span>
+          </div>
+          <Link
+            to="/notifications"
+            onClick={() => setOpen(false)}
+            className="text-xs font-semibold text-[#3A7FFF] transition-colors hover:text-[#2D9B66]"
+          >
+            View all
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationBell;

--- a/src/components/notifications/NotificationPreferencesForm.tsx
+++ b/src/components/notifications/NotificationPreferencesForm.tsx
@@ -1,0 +1,143 @@
+import { ChangeEvent } from 'react';
+import { cn } from '../../utils/cn';
+import { useNotificationCenter } from '../../context/NotificationContext';
+
+const ToggleRow = ({
+  label,
+  description,
+  enabled,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  enabled: boolean;
+  onChange: (value: boolean) => void;
+}) => (
+  <div className="flex items-start justify-between rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm transition hover:border-[#3A7FFF]/40 dark:border-slate-700 dark:bg-slate-900">
+    <div className="pr-4">
+      <p className="text-sm font-semibold text-slate-900 dark:text-white" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+        {label}
+      </p>
+      <p className="text-xs text-slate-500 dark:text-slate-300" style={{ fontFamily: 'Lato, sans-serif' }}>
+        {description}
+      </p>
+    </div>
+    <button
+      type="button"
+      onClick={() => onChange(!enabled)}
+      className={cn(
+        enabled ? 'bg-[#2D9B66]' : 'bg-slate-300',
+        'relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#3A7FFF]'
+      )}
+      role="switch"
+      aria-checked={enabled}
+      aria-label={`Toggle ${label}`}
+    >
+      <span
+        className={cn(
+          enabled ? 'translate-x-6' : 'translate-x-1',
+          'inline-block h-4 w-4 transform rounded-full bg-white transition-transform'
+        )}
+      />
+    </button>
+  </div>
+);
+
+const NotificationPreferencesForm = () => {
+  const { preferences, setPreferences } = useNotificationCenter();
+
+  const handleToggle = (key: keyof typeof preferences) => (value: boolean) => {
+    setPreferences({ [key]: value });
+  };
+
+  const handleDigestChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setPreferences({ digestFrequency: event.target.value as typeof preferences.digestFrequency });
+  };
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-2">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+          Notification Preferences
+        </h2>
+        <p className="text-sm text-slate-600 dark:text-slate-300" style={{ fontFamily: 'Lato, sans-serif' }}>
+          Choose which updates you want to receive and how often we should send summaries.
+        </p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ToggleRow
+          label="Course assignments"
+          description="Get alerts the moment a new course or module is assigned to you."
+          enabled={preferences.assignments}
+          onChange={handleToggle('assignments')}
+        />
+        <ToggleRow
+          label="Course updates"
+          description="Stay informed when modules change or new lessons drop."
+          enabled={preferences.courseUpdates}
+          onChange={handleToggle('courseUpdates')}
+        />
+        <ToggleRow
+          label="Survey reminders"
+          description="Receive nudges before surveys become due."
+          enabled={preferences.surveyReminders}
+          onChange={handleToggle('surveyReminders')}
+        />
+        <ToggleRow
+          label="Celebration messages"
+          description="Celebrate milestones with a congratulatory note."
+          enabled={preferences.completionCelebrations}
+          onChange={handleToggle('completionCelebrations')}
+        />
+        <ToggleRow
+          label="Announcements"
+          description="Hear about leadership updates and organization-wide news."
+          enabled={preferences.announcements}
+          onChange={handleToggle('announcements')}
+        />
+        <ToggleRow
+          label="System updates"
+          description="Know about planned maintenance or new LMS features."
+          enabled={preferences.systemUpdates}
+          onChange={handleToggle('systemUpdates')}
+        />
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <label className="flex flex-col space-y-2 text-sm font-medium text-slate-700 dark:text-slate-200" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+          Digest frequency
+          <span className="text-xs font-normal text-slate-500 dark:text-slate-400" style={{ fontFamily: 'Lato, sans-serif' }}>
+            Receive a summary of unread items delivered straight to your inbox.
+          </span>
+          <select
+            value={preferences.digestFrequency}
+            onChange={handleDigestChange}
+            className="mt-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF] dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+          >
+            <option value="daily">Daily summary</option>
+            <option value="weekly">Weekly digest</option>
+            <option value="off">Turn off email summaries</option>
+          </select>
+        </label>
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <ToggleRow
+            label="Allow push alerts"
+            description="Enable browser and mobile push notifications for instant updates."
+            enabled={preferences.allowPush}
+            onChange={handleToggle('allowPush')}
+          />
+          <ToggleRow
+            label="Email summaries"
+            description="Receive in-app updates as part of an email summary."
+            enabled={preferences.emailSummary}
+            onChange={handleToggle('emailSummary')}
+          />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default NotificationPreferencesForm;

--- a/src/context/NotificationContext.tsx
+++ b/src/context/NotificationContext.tsx
@@ -1,0 +1,264 @@
+import {
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  NotificationAnalytics,
+  NotificationEvent,
+  NotificationInput,
+  NotificationPreferences,
+  NotificationRecord,
+} from '../types/notifications';
+import {
+  archiveNotification,
+  createNotification as serviceCreateNotification,
+  deleteNotification,
+  fetchNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+  persistNotificationCache,
+  loadNotificationCache,
+  subscribeToNotifications,
+} from '../services/notificationService';
+import {
+  buildNotificationAnalytics,
+  getNotificationEvents,
+  logNotificationEvent,
+} from '../services/notificationAnalyticsService';
+
+interface NotificationContextValue {
+  notifications: NotificationRecord[];
+  unreadCount: number;
+  loading: boolean;
+  error?: string;
+  preferences: NotificationPreferences;
+  analytics: NotificationAnalytics;
+  events: NotificationEvent[];
+  refresh: () => Promise<void>;
+  create: (input: NotificationInput) => Promise<NotificationRecord>;
+  markAsRead: (id: string) => Promise<void>;
+  markAsUnread: (id: string) => Promise<void>;
+  markAllAsRead: () => Promise<void>;
+  archive: (id: string) => Promise<void>;
+  restore: (id: string) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+  recordClick: (id: string) => void;
+  setPreferences: (preferences: Partial<NotificationPreferences>) => void;
+}
+
+const NotificationContext = createContext<NotificationContextValue | undefined>(undefined);
+
+const PREFERENCE_STORAGE_KEY = 'huddle_notification_preferences_v1';
+
+const loadPreferences = (): NotificationPreferences => {
+  try {
+    const raw = localStorage.getItem(PREFERENCE_STORAGE_KEY);
+    if (!raw) return DEFAULT_NOTIFICATION_PREFERENCES;
+    return { ...DEFAULT_NOTIFICATION_PREFERENCES, ...JSON.parse(raw) } as NotificationPreferences;
+  } catch (error) {
+    console.warn('[NotificationContext] Failed to load preferences', error);
+    return DEFAULT_NOTIFICATION_PREFERENCES;
+  }
+};
+
+const persistPreferences = (preferences: NotificationPreferences) => {
+  try {
+    localStorage.setItem(PREFERENCE_STORAGE_KEY, JSON.stringify(preferences));
+  } catch (error) {
+    console.warn('[NotificationContext] Failed to persist preferences', error);
+  }
+};
+
+export const NotificationProvider = ({ children }: PropsWithChildren) => {
+  const [notifications, setNotifications] = useState<NotificationRecord[]>(loadNotificationCache);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [preferences, setPreferencesState] = useState<NotificationPreferences>(loadPreferences);
+  const [events, setEvents] = useState<NotificationEvent[]>(getNotificationEvents);
+
+  const syncCache = useCallback((items: NotificationRecord[]) => {
+    setNotifications(items);
+    persistNotificationCache(items);
+  }, []);
+
+  const handleRefresh = useCallback(async () => {
+    try {
+      setLoading(true);
+      const result = await fetchNotifications();
+      syncCache(result);
+      setEvents(getNotificationEvents());
+      setError(undefined);
+    } catch (err) {
+      console.error('[NotificationContext] Failed to fetch notifications', err);
+      setError(err instanceof Error ? err.message : 'Unable to load notifications');
+    } finally {
+      setLoading(false);
+    }
+  }, [syncCache]);
+
+  useEffect(() => {
+    handleRefresh();
+  }, [handleRefresh]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToNotifications((eventType, record) => {
+      setNotifications((current) => {
+        if (eventType === 'DELETE') {
+          const updated = current.filter((item) => item.id !== record.id);
+          persistNotificationCache(updated);
+          return updated;
+        }
+
+        const exists = current.some((item) => item.id === record.id);
+        let updated: NotificationRecord[];
+        if (exists) {
+          updated = current.map((item) => (item.id === record.id ? { ...item, ...record } : item));
+        } else {
+          updated = [record, ...current];
+        }
+        persistNotificationCache(updated);
+
+        if (!exists) {
+          const deliveredEvent = logNotificationEvent(record.id, 'delivered', record.recipientUserId);
+          setEvents((prev) => [...prev, deliveredEvent]);
+        }
+        return updated;
+      });
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, []);
+
+  const create = useCallback(async (input: NotificationInput) => {
+    const created = await serviceCreateNotification(input);
+    setNotifications((prev) => {
+      const updated = [created, ...prev.filter((item) => item.id !== created.id)];
+      persistNotificationCache(updated);
+      return updated;
+    });
+    const deliveredEvent = logNotificationEvent(created.id, 'delivered', created.recipientUserId);
+    setEvents((prev) => [...prev, deliveredEvent]);
+    return created;
+  }, []);
+
+  const markAsRead = useCallback(async (id: string) => {
+    await markNotificationRead(id, true);
+    setNotifications((prev) => {
+      const updated = prev.map((item) => (item.id === id ? { ...item, isRead: true } : item));
+      persistNotificationCache(updated);
+      return updated;
+    });
+    const readEvent = logNotificationEvent(id, 'read');
+    setEvents((prev) => [...prev, readEvent]);
+  }, []);
+
+  const markAsUnread = useCallback(async (id: string) => {
+    await markNotificationRead(id, false);
+    setNotifications((prev) => {
+      const updated = prev.map((item) => (item.id === id ? { ...item, isRead: false } : item));
+      persistNotificationCache(updated);
+      return updated;
+    });
+  }, []);
+
+  const markAllAsReadHandler = useCallback(async () => {
+    await markAllNotificationsRead();
+    setNotifications((prev) => {
+      const updated = prev.map((item) => ({ ...item, isRead: true }));
+      persistNotificationCache(updated);
+      return updated;
+    });
+  }, []);
+
+  const archive = useCallback(async (id: string) => {
+    await archiveNotification(id, true);
+    setNotifications((prev) => {
+      const updated = prev.map((item) => (item.id === id ? { ...item, archived: true } : item));
+      persistNotificationCache(updated);
+      return updated;
+    });
+    const archivedEvent = logNotificationEvent(id, 'archived');
+    setEvents((prev) => [...prev, archivedEvent]);
+  }, []);
+
+  const restore = useCallback(async (id: string) => {
+    await archiveNotification(id, false);
+    setNotifications((prev) => {
+      const updated = prev.map((item) => (item.id === id ? { ...item, archived: false } : item));
+      persistNotificationCache(updated);
+      return updated;
+    });
+  }, []);
+
+  const remove = useCallback(async (id: string) => {
+    await deleteNotification(id);
+    setNotifications((prev) => {
+      const updated = prev.filter((item) => item.id !== id);
+      persistNotificationCache(updated);
+      return updated;
+    });
+    const deletedEvent = logNotificationEvent(id, 'deleted');
+    setEvents((prev) => [...prev, deletedEvent]);
+  }, []);
+
+  const recordClick = useCallback((id: string) => {
+    const clickEvent = logNotificationEvent(id, 'clicked');
+    setEvents((prev) => [...prev, clickEvent]);
+  }, []);
+
+  const setPreferences = useCallback((partial: Partial<NotificationPreferences>) => {
+    setPreferencesState((prev) => {
+      const next = { ...prev, ...partial };
+      persistPreferences(next);
+      return next;
+    });
+  }, []);
+
+  const analytics: NotificationAnalytics = useMemo(
+    () => buildNotificationAnalytics(notifications, events),
+    [notifications, events]
+  );
+
+  const unreadCount = useMemo(
+    () => notifications.filter((item) => !item.isRead && !item.archived).length,
+    [notifications]
+  );
+
+  const value: NotificationContextValue = {
+    notifications,
+    unreadCount,
+    loading,
+    error,
+    preferences,
+    analytics,
+    events,
+    refresh: handleRefresh,
+    create,
+    markAsRead,
+    markAsUnread,
+    markAllAsRead: markAllAsReadHandler,
+    archive,
+    restore,
+    remove,
+    recordClick,
+    setPreferences,
+  };
+
+  return <NotificationContext.Provider value={value}>{children}</NotificationContext.Provider>;
+};
+
+export const useNotificationCenter = () => {
+  const context = useContext(NotificationContext);
+  if (!context) {
+    throw new Error('useNotificationCenter must be used within a NotificationProvider');
+  }
+  return context;
+};

--- a/src/data/notificationTemplates.ts
+++ b/src/data/notificationTemplates.ts
@@ -1,0 +1,64 @@
+import { NotificationInput } from '../types/notifications';
+
+export type NotificationTemplate = NotificationInput & {
+  id: string;
+  description: string;
+};
+
+export const notificationTemplates: NotificationTemplate[] = [
+  {
+    id: 'course-assignment',
+    description: 'Announce a newly assigned course to learners.',
+    type: 'assignment',
+    category: 'alert',
+    priority: 'high',
+    title: 'New Course Assigned',
+    message: 'You have been assigned to a new development experience. Start today to stay on track.',
+    actionLabel: 'Open Course',
+  },
+  {
+    id: 'survey-reminder',
+    description: 'Nudge participants to complete an upcoming survey.',
+    type: 'survey_reminder',
+    category: 'reminder',
+    priority: 'medium',
+    title: 'Survey Reminder',
+    message: 'A new inclusion pulse check is waiting for you. We value your voice—please share your perspective.',
+    actionLabel: 'Take Survey',
+  },
+  {
+    id: 'completion-celebration',
+    description: 'Congratulate learners on a recent achievement.',
+    type: 'completion',
+    category: 'celebration',
+    priority: 'medium',
+    title: 'Congratulations on Your Milestone!',
+    message: 'You just completed a major milestone. Celebrate the progress and explore what’s next.',
+    actionLabel: 'View Progress',
+  },
+  {
+    id: 'system-update',
+    description: 'Share platform updates or maintenance notifications.',
+    type: 'system',
+    category: 'announcement',
+    priority: 'low',
+    title: 'Platform Update',
+    message: 'We are rolling out performance upgrades this weekend. Expect a smoother experience on Monday.',
+    actionLabel: 'Read Details',
+  },
+  {
+    id: 'broadcast-ceo',
+    description: 'Broadcast organization-wide leadership announcements.',
+    type: 'broadcast',
+    category: 'announcement',
+    priority: 'urgent',
+    title: 'Leadership Update',
+    message: 'Our CEO just shared new DEI commitments for the upcoming quarter. Review the highlights and next steps.',
+    actionLabel: 'View Announcement',
+  },
+];
+
+export const findTemplateById = (templateId: string) =>
+  notificationTemplates.find((template) => template.id === templateId);
+
+export default notificationTemplates;

--- a/src/pages/Admin/AdminBroadcastCenter.tsx
+++ b/src/pages/Admin/AdminBroadcastCenter.tsx
@@ -1,0 +1,449 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { format } from 'date-fns';
+import {
+  AlarmClock,
+  BarChart3,
+  CalendarClock,
+  Inbox,
+  Laptop2,
+  Megaphone,
+  Send,
+  Sparkles,
+  Users2,
+} from 'lucide-react';
+import toast from 'react-hot-toast';
+import { cn } from '../../utils/cn';
+import { useNotificationCenter } from '../../context/NotificationContext';
+import { useAuth } from '../../context/AuthContext';
+import { findTemplateById, notificationTemplates } from '../../data/notificationTemplates';
+import type { NotificationInput, NotificationRecord } from '../../types/notifications';
+
+interface BroadcastFormState {
+  templateId?: string;
+  title: string;
+  message: string;
+  type: NotificationRecord['type'];
+  category: NotificationRecord['category'];
+  priority: NotificationRecord['priority'];
+  actionLabel: string;
+  link: string;
+  recipientScope: 'all' | 'org' | 'user';
+  recipientOrgId?: string;
+  recipientUserId?: string;
+  expiresAt?: string;
+  scheduleAt?: string;
+}
+
+const defaultState: BroadcastFormState = {
+  title: '',
+  message: '',
+  type: 'broadcast',
+  category: 'announcement',
+  priority: 'medium',
+  actionLabel: 'View announcement',
+  link: '',
+  recipientScope: 'all',
+};
+
+const AdminBroadcastCenter = () => {
+  const { create, notifications, analytics } = useNotificationCenter();
+  const { user } = useAuth();
+  const [form, setForm] = useState<BroadcastFormState>(defaultState);
+  const [submitting, setSubmitting] = useState(false);
+
+  const adminId = user?.id ?? 'admin-demo';
+
+  const adminHistory = useMemo(
+    () =>
+      notifications
+        .filter((note) => note.senderId === adminId)
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .slice(0, 10),
+    [notifications, adminId]
+  );
+
+  const handleTemplateSelect = (templateId: string) => {
+    const template = findTemplateById(templateId);
+    if (!template) return;
+    setForm((prev) => ({
+      ...prev,
+      templateId,
+      title: template.title ?? prev.title,
+      message: template.message ?? prev.message,
+      type: template.type ?? prev.type,
+      category: template.category ?? prev.category,
+      priority: template.priority ?? prev.priority,
+      actionLabel: template.actionLabel ?? prev.actionLabel,
+    }));
+  };
+
+  const handleChange = (key: keyof BroadcastFormState, value: string) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setSubmitting(true);
+    const scheduleDate = form.scheduleAt ? new Date(form.scheduleAt) : undefined;
+    const isScheduled = scheduleDate && scheduleDate.getTime() > Date.now();
+
+    const payload: NotificationInput = {
+      title: form.title,
+      message: form.message,
+      type: form.type,
+      category: form.category,
+      priority: form.priority,
+      actionLabel: form.actionLabel,
+      link: form.link || undefined,
+      recipientOrgId: form.recipientScope === 'org' ? form.recipientOrgId ?? undefined : null,
+      recipientUserId: form.recipientScope === 'user' ? form.recipientUserId ?? undefined : null,
+      senderId: adminId,
+      expiresAt: form.expiresAt || undefined,
+      metadata: {
+        templateId: form.templateId,
+        scheduledFor: scheduleDate?.toISOString(),
+        deliveryStatus: isScheduled ? 'scheduled' : 'sent',
+      },
+      isRead: false,
+      createdAt: isScheduled ? scheduleDate?.toISOString() : undefined,
+    };
+
+    try {
+      await create(payload);
+      toast.success(isScheduled ? 'Broadcast scheduled successfully.' : 'Broadcast sent successfully.');
+      setForm(defaultState);
+    } catch (error) {
+      console.error('Failed to send broadcast', error);
+      toast.error('Unable to send broadcast notification.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const preview: NotificationInput = {
+    title: form.title || 'Broadcast preview',
+    message: form.message || 'Compose a message to preview how learners will see it.',
+    type: form.type,
+    priority: form.priority,
+    category: form.category,
+    actionLabel: form.actionLabel,
+  };
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-10 py-10">
+      <header className="rounded-3xl bg-gradient-to-r from-[#3A7FFF] via-[#FF8895] to-[#D72638] p-[1px]">
+        <div className="rounded-[calc(1.5rem-1px)] bg-white px-8 py-10 text-slate-900 shadow-xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-[#D72638]/80">Messaging control center</p>
+          <div className="mt-4 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-3">
+              <h1 className="text-3xl font-bold" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+                Broadcast announcements & in-app alerts
+              </h1>
+              <p className="max-w-2xl text-sm text-slate-600" style={{ fontFamily: 'Lato, sans-serif' }}>
+                Deliver real-time course alerts, survey nudges, and system updates across the LMS. Schedule communications, reuse templates, and monitor engagement without leaving the admin workspace.
+              </p>
+            </div>
+            <div className="rounded-2xl bg-[#3A7FFF]/10 px-6 py-4 text-sm text-[#3A7FFF]">
+              <p className="font-semibold">Real-time status</p>
+              <p>{analytics.unread} unread • {(analytics.openRate * 100).toFixed(0)}% open rate</p>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <form onSubmit={handleSubmit} className="space-y-6 rounded-3xl border border-slate-200 bg-white p-8 shadow-xl">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+                Compose broadcast
+              </h2>
+              <p className="text-sm text-slate-500">Send to the entire network, specific organizations, or individual learners.</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <CalendarClock className="h-5 w-5 text-[#3A7FFF]" aria-hidden="true" />
+              <span className="text-xs text-slate-500">Schedule optional for future delivery</span>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col space-y-1 text-sm font-medium text-slate-700">
+              Title
+              <input
+                required
+                value={form.title}
+                onChange={(event) => handleChange('title', event.target.value)}
+                className="rounded-xl border border-slate-200 px-4 py-2 text-sm focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF]"
+                placeholder="Inclusive leadership update"
+              />
+            </label>
+            <label className="flex flex-col space-y-1 text-sm font-medium text-slate-700">
+              Action label
+              <input
+                value={form.actionLabel}
+                onChange={(event) => handleChange('actionLabel', event.target.value)}
+                className="rounded-xl border border-slate-200 px-4 py-2 text-sm focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF]"
+                placeholder="View announcement"
+              />
+            </label>
+          </div>
+
+          <label className="flex flex-col space-y-1 text-sm font-medium text-slate-700">
+            Message body
+            <textarea
+              required
+              rows={5}
+              value={form.message}
+              onChange={(event) => handleChange('message', event.target.value)}
+              className="rounded-2xl border border-slate-200 px-4 py-3 text-sm leading-6 focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF]"
+              placeholder="Share what’s new, why it matters, and the next action to take."
+            />
+          </label>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <label className="flex flex-col space-y-1 text-sm font-medium text-slate-700">
+              Notification type
+              <select
+                value={form.type}
+                onChange={(event) => handleChange('type', event.target.value)}
+                className="rounded-xl border border-slate-200 px-4 py-2 text-sm focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF]"
+              >
+                <option value="broadcast">Broadcast announcement</option>
+                <option value="assignment">Assignment alert</option>
+                <option value="course_update">Course update</option>
+                <option value="survey_reminder">Survey reminder</option>
+                <option value="completion">Completion celebration</option>
+                <option value="system">System update</option>
+                <option value="message">Direct message</option>
+              </select>
+            </label>
+            <label className="flex flex-col space-y-1 text-sm font-medium text-slate-700">
+              Category
+              <select
+                value={form.category}
+                onChange={(event) => handleChange('category', event.target.value)}
+                className="rounded-xl border border-slate-200 px-4 py-2 text-sm focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF]"
+              >
+                <option value="announcement">Announcement</option>
+                <option value="alert">Alert</option>
+                <option value="reminder">Reminder</option>
+                <option value="celebration">Celebration</option>
+                <option value="update">Update</option>
+              </select>
+            </label>
+            <label className="flex flex-col space-y-1 text-sm font-medium text-slate-700">
+              Priority
+              <select
+                value={form.priority}
+                onChange={(event) => handleChange('priority', event.target.value)}
+                className="rounded-xl border border-slate-200 px-4 py-2 text-sm focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF]"
+              >
+                <option value="medium">Medium</option>
+                <option value="urgent">Urgent</option>
+                <option value="high">High</option>
+                <option value="low">Low</option>
+              </select>
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <label className="flex flex-col space-y-1 text-sm font-medium text-slate-700">
+              Action link
+              <input
+                value={form.link}
+                onChange={(event) => handleChange('link', event.target.value)}
+                placeholder="/client/course/123"
+                className="rounded-xl border border-slate-200 px-4 py-2 text-sm focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF]"
+              />
+            </label>
+            <label className="flex flex-col space-y-1 text-sm font-medium text-slate-700">
+              Expiration (optional)
+              <input
+                type="date"
+                value={form.expiresAt ?? ''}
+                onChange={(event) => handleChange('expiresAt', event.target.value)}
+                className="rounded-xl border border-slate-200 px-4 py-2 text-sm focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF]"
+              />
+            </label>
+            <label className="flex flex-col space-y-1 text-sm font-medium text-slate-700">
+              Schedule send
+              <input
+                type="datetime-local"
+                value={form.scheduleAt ?? ''}
+                onChange={(event) => handleChange('scheduleAt', event.target.value)}
+                className="rounded-xl border border-slate-200 px-4 py-2 text-sm focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF]"
+              />
+            </label>
+          </div>
+
+          <fieldset className="space-y-3 rounded-2xl border border-slate-200 p-4">
+            <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-slate-500">Recipients</legend>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {([
+                { value: 'all', label: 'All learners', icon: <Megaphone className="h-4 w-4" aria-hidden="true" /> },
+                { value: 'org', label: 'Specific organization', icon: <Users2 className="h-4 w-4" aria-hidden="true" /> },
+                { value: 'user', label: 'Individual user', icon: <Laptop2 className="h-4 w-4" aria-hidden="true" /> },
+              ] as const).map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => handleChange('recipientScope', option.value)}
+                  className={cn(
+                    'flex items-center gap-2 rounded-xl border px-4 py-3 text-sm font-semibold transition',
+                    form.recipientScope === option.value
+                      ? 'border-[#3A7FFF] bg-[#3A7FFF]/10 text-[#3A7FFF]'
+                      : 'border-slate-200 text-slate-600 hover:border-[#3A7FFF] hover:text-[#3A7FFF]'
+                  )}
+                >
+                  {option.icon}
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            {form.recipientScope === 'org' && (
+              <input
+                value={form.recipientOrgId ?? ''}
+                onChange={(event) => handleChange('recipientOrgId', event.target.value)}
+                placeholder="Organization ID"
+                className="w-full rounded-xl border border-slate-200 px-4 py-2 text-sm focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF]"
+              />
+            )}
+            {form.recipientScope === 'user' && (
+              <input
+                value={form.recipientUserId ?? ''}
+                onChange={(event) => handleChange('recipientUserId', event.target.value)}
+                placeholder="User ID or email"
+                className="w-full rounded-xl border border-slate-200 px-4 py-2 text-sm focus:border-[#3A7FFF] focus:outline-none focus:ring-2 focus:ring-[#3A7FFF]"
+              />
+            )}
+          </fieldset>
+
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="flex items-center gap-2 text-xs text-slate-500">
+              <AlarmClock className="h-4 w-4 text-[#3A7FFF]" aria-hidden="true" />
+              <span>
+                Scheduled send: {form.scheduleAt ? format(new Date(form.scheduleAt), 'PPpp') : 'Send immediately'}
+              </span>
+            </div>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex items-center gap-2 rounded-full bg-[#D72638] px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-[#b11f2d] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Send className="h-4 w-4" aria-hidden="true" />
+              {submitting ? 'Sending…' : 'Send broadcast'}
+            </button>
+          </div>
+        </form>
+
+        <aside className="space-y-6">
+          <section className="space-y-3 rounded-3xl border border-slate-200 bg-white p-6 shadow-xl">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+                Engagement overview
+              </h2>
+              <Users2 className="h-5 w-5 text-[#2D9B66]" aria-hidden="true" />
+            </div>
+            {analytics.engagementByOrg.length === 0 ? (
+              <p className="text-sm text-slate-500">No organization-specific analytics yet. Send a targeted broadcast to see reach metrics.</p>
+            ) : (
+              <ul className="space-y-3 text-sm">
+                {analytics.engagementByOrg.map((org) => (
+                  <li key={org.orgId} className="rounded-2xl border border-slate-200 px-4 py-3">
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold text-slate-900">Org {org.orgId}</span>
+                      <span className="text-xs text-slate-400">{((org.read / Math.max(org.sent, 1)) * 100).toFixed(0)}% opened</span>
+                    </div>
+                    <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-slate-500">
+                      <span className="rounded-lg bg-[#3A7FFF]/10 px-2 py-1 font-semibold text-[#3A7FFF]">Sent {org.sent}</span>
+                      <span className="rounded-lg bg-[#2D9B66]/10 px-2 py-1 font-semibold text-[#2D9B66]">Read {org.read}</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+          <section className="space-y-3 rounded-3xl border border-slate-200 bg-white p-6 shadow-xl">
+            <h2 className="text-lg font-semibold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+              Templates
+            </h2>
+            <p className="text-sm text-slate-500">Start from a proven message, then tailor it to your learners.</p>
+            <div className="space-y-3">
+              {notificationTemplates.map((template) => (
+                <button
+                  key={template.id}
+                  type="button"
+                  onClick={() => handleTemplateSelect(template.id)}
+                  className={cn(
+                    'w-full rounded-2xl border px-4 py-3 text-left transition hover:border-[#3A7FFF] hover:shadow-lg',
+                    form.templateId === template.id ? 'border-[#3A7FFF] bg-[#3A7FFF]/10' : 'border-slate-200'
+                  )}
+                >
+                  <p className="text-sm font-semibold text-slate-900">{template.title}</p>
+                  <p className="text-xs text-slate-500">{template.description}</p>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3 rounded-3xl border border-slate-200 bg-white p-6 shadow-xl">
+            <h2 className="text-lg font-semibold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+              Preview
+            </h2>
+            <div className="rounded-2xl border border-slate-200 bg-gradient-to-br from-[#3A7FFF]/10 to-[#FF8895]/10 p-5">
+              <div className="flex items-center gap-3">
+                <Sparkles className="h-5 w-5 text-[#3A7FFF]" aria-hidden="true" />
+                <span className="text-xs font-semibold uppercase tracking-wide text-[#3A7FFF]">
+                  {preview.category}
+                </span>
+              </div>
+              <h3 className="mt-3 text-lg font-semibold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+                {preview.title}
+              </h3>
+              <p className="mt-2 text-sm text-slate-600" style={{ fontFamily: 'Lato, sans-serif' }}>
+                {preview.message}
+              </p>
+              <button className="mt-4 inline-flex items-center gap-2 rounded-full bg-[#3A7FFF] px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white">
+                {preview.actionLabel || 'View details'}
+              </button>
+            </div>
+          </section>
+
+          <section className="space-y-3 rounded-3xl border border-slate-200 bg-white p-6 shadow-xl">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+                Recent broadcasts
+              </h2>
+              <BarChart3 className="h-5 w-5 text-[#3A7FFF]" aria-hidden="true" />
+            </div>
+            {adminHistory.length === 0 ? (
+              <div className="flex flex-col items-center gap-2 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-10 text-center text-sm text-slate-500">
+                <Inbox className="h-8 w-8 text-slate-300" aria-hidden="true" />
+                <p>No broadcasts yet.</p>
+                <p className="text-xs">Compose a message to see analytics here.</p>
+              </div>
+            ) : (
+              <ul className="space-y-3 text-sm">
+                {adminHistory.map((note) => (
+                  <li key={note.id} className="rounded-2xl border border-slate-200 p-4">
+                    <div className="flex items-center justify-between">
+                      <p className="font-semibold text-slate-900">{note.title}</p>
+                      <span className="text-xs text-slate-400">{format(new Date(note.createdAt), 'PP')}</span>
+                    </div>
+                    <p className="mt-1 text-xs text-slate-500">{note.message}</p>
+                    <div className="mt-2 flex items-center gap-3 text-xs text-slate-500">
+                      <span>{note.priority.toUpperCase()}</span>
+                      {note.recipientOrgId ? <span>Org: {note.recipientOrgId}</span> : <span>All users</span>}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </aside>
+      </section>
+    </div>
+  );
+};
+
+export default AdminBroadcastCenter;

--- a/src/pages/LMS/LMSSettings.tsx
+++ b/src/pages/LMS/LMSSettings.tsx
@@ -13,6 +13,7 @@ import {
 import SEO from '../../components/SEO/SEO';
 import { useToast } from '../../context/ToastContext';
 import { useAuth } from '../../context/AuthContext';
+import NotificationPreferencesForm from '../../components/notifications/NotificationPreferencesForm';
 
 interface UserSettings {
   profile: {
@@ -332,73 +333,7 @@ const LMSSettings: React.FC = () => {
                 {/* Notification Settings */}
                 {activeSection === 'notifications' && (
                   <div className="p-6">
-                    <h2 className="text-lg font-medium text-gray-900 mb-6">Notification Preferences</h2>
-                    
-                    <div className="space-y-6">
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <h3 className="text-sm font-medium text-gray-700">Email Notifications</h3>
-                          <p className="text-xs text-gray-500">Receive notifications via email</p>
-                        </div>
-                        <label className="relative inline-flex items-center cursor-pointer">
-                          <input
-                            type="checkbox"
-                            checked={settings.preferences.notifications.email}
-                            onChange={(e) => updateNotificationSetting('email', e.target.checked)}
-                            className="sr-only peer"
-                          />
-                          <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-orange-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-orange-500"></div>
-                        </label>
-                      </div>
-                      
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <h3 className="text-sm font-medium text-gray-700">Course Reminders</h3>
-                          <p className="text-xs text-gray-500">Get reminders about upcoming courses</p>
-                        </div>
-                        <label className="relative inline-flex items-center cursor-pointer">
-                          <input
-                            type="checkbox"
-                            checked={settings.preferences.notifications.courseReminders}
-                            onChange={(e) => updateNotificationSetting('courseReminders', e.target.checked)}
-                            className="sr-only peer"
-                          />
-                          <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-orange-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-orange-500"></div>
-                        </label>
-                      </div>
-                      
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <h3 className="text-sm font-medium text-gray-700">Completion Notifications</h3>
-                          <p className="text-xs text-gray-500">Celebrate when you complete courses</p>
-                        </div>
-                        <label className="relative inline-flex items-center cursor-pointer">
-                          <input
-                            type="checkbox"
-                            checked={settings.preferences.notifications.completionNotifications}
-                            onChange={(e) => updateNotificationSetting('completionNotifications', e.target.checked)}
-                            className="sr-only peer"
-                          />
-                          <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-orange-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-orange-500"></div>
-                        </label>
-                      </div>
-                      
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <h3 className="text-sm font-medium text-gray-700">Weekly Progress Reports</h3>
-                          <p className="text-xs text-gray-500">Receive weekly summaries of your learning progress</p>
-                        </div>
-                        <label className="relative inline-flex items-center cursor-pointer">
-                          <input
-                            type="checkbox"
-                            checked={settings.preferences.notifications.weeklyProgress}
-                            onChange={(e) => updateNotificationSetting('weeklyProgress', e.target.checked)}
-                            className="sr-only peer"
-                          />
-                          <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-orange-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-orange-500"></div>
-                        </label>
-                      </div>
-                    </div>
+                    <NotificationPreferencesForm />
                   </div>
                 )}
 

--- a/src/pages/NotificationsHubPage.tsx
+++ b/src/pages/NotificationsHubPage.tsx
@@ -1,0 +1,420 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  AlertTriangle,
+  Archive,
+  BellRing,
+  CheckCircle2,
+  Filter,
+  Inbox,
+  ListFilter,
+  Loader2,
+  MailOpen,
+  Megaphone,
+  RefreshCcw,
+  Trash2,
+} from 'lucide-react';
+import { cn } from '../utils/cn';
+import { useNotificationCenter } from '../context/NotificationContext';
+import type { NotificationRecord } from '../types/notifications';
+
+const PAGE_SIZE = 10;
+
+const formatRelativeTime = (iso: string) => {
+  const date = new Date(iso);
+  const diff = Date.now() - date.getTime();
+  const minutes = Math.round(diff / 60000);
+  if (minutes < 1) return 'Just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+};
+
+const priorityColor = (notification: NotificationRecord) => {
+  switch (notification.priority) {
+    case 'urgent':
+      return 'bg-[#D72638]/10 text-[#D72638]';
+    case 'high':
+      return 'bg-[#FF8895]/20 text-[#D72638]';
+    case 'medium':
+      return 'bg-[#3A7FFF]/15 text-[#3A7FFF]';
+    default:
+      return 'bg-slate-200 text-slate-700';
+  }
+};
+
+const typeLabelMap: Record<NotificationRecord['type'], string> = {
+  assignment: 'Assignment',
+  broadcast: 'Broadcast',
+  completion: 'Celebration',
+  course_update: 'Course update',
+  survey_reminder: 'Survey reminder',
+  system: 'System update',
+  message: 'Message',
+};
+
+const categoryColor = (category: NotificationRecord['category']) => {
+  switch (category) {
+    case 'alert':
+      return 'bg-[#D72638]/15 text-[#D72638]';
+    case 'announcement':
+      return 'bg-[#3A7FFF]/15 text-[#3A7FFF]';
+    case 'celebration':
+      return 'bg-[#FF8895]/20 text-white';
+    case 'reminder':
+      return 'bg-[#2D9B66]/15 text-[#2D9B66]';
+    case 'update':
+    default:
+      return 'bg-slate-200 text-slate-700';
+  }
+};
+
+const NotificationsHubPage = () => {
+  const {
+    notifications,
+    loading,
+    markAsRead,
+    markAsUnread,
+    markAllAsRead,
+    archive,
+    restore,
+    remove,
+    refresh,
+    analytics,
+  } = useNotificationCenter();
+
+  const [typeFilter, setTypeFilter] = useState<'all' | NotificationRecord['type']>('all');
+  const [categoryFilter, setCategoryFilter] = useState<'all' | NotificationRecord['category']>('all');
+  const [showArchived, setShowArchived] = useState(false);
+  const [sortOption, setSortOption] = useState<'newest' | 'oldest' | 'priority'>('newest');
+  const [page, setPage] = useState(1);
+
+  const filtered = useMemo(() => {
+    let result = notifications.filter((notification) =>
+      showArchived ? notification.archived : !notification.archived
+    );
+
+    if (typeFilter !== 'all') {
+      result = result.filter((notification) => notification.type === typeFilter);
+    }
+    if (categoryFilter !== 'all') {
+      result = result.filter((notification) => notification.category === categoryFilter);
+    }
+
+    if (sortOption === 'priority') {
+      const priorityOrder = ['urgent', 'high', 'medium', 'low'];
+      result = [...result].sort(
+        (a, b) => priorityOrder.indexOf(a.priority) - priorityOrder.indexOf(b.priority)
+      );
+    } else {
+      result = [...result].sort((a, b) => {
+        const aTime = new Date(a.createdAt).getTime();
+        const bTime = new Date(b.createdAt).getTime();
+        return sortOption === 'oldest' ? aTime - bTime : bTime - aTime;
+      });
+    }
+
+    return result;
+  }, [notifications, typeFilter, categoryFilter, showArchived, sortOption]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const pageItems = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const handlePageChange = (nextPage: number) => {
+    setPage(Math.min(totalPages, Math.max(1, nextPage)));
+  };
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-8 px-4 py-10">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#3A7FFF]">Unified communications</p>
+          <h1 className="text-3xl font-bold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+            Notification center
+          </h1>
+          <p className="text-sm text-slate-600" style={{ fontFamily: 'Lato, sans-serif' }}>
+            Review announcements, assignments, and reminders in one feed. Everything syncs instantly across devices.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            onClick={() => refresh()}
+            className="inline-flex items-center space-x-2 rounded-full border border-[#3A7FFF] px-4 py-2 text-sm font-semibold text-[#3A7FFF] transition hover:bg-[#3A7FFF] hover:text-white"
+          >
+            <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+            <span>Refresh feed</span>
+          </button>
+          <button
+            onClick={() => markAllAsRead()}
+            className="inline-flex items-center space-x-2 rounded-full bg-[#2D9B66] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#238756]"
+          >
+            <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+            <span>Mark all read</span>
+          </button>
+        </div>
+      </header>
+
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <p className="text-xs uppercase tracking-wide text-slate-500" style={{ fontFamily: 'Lato, sans-serif' }}>
+            Total delivered
+          </p>
+          <div className="mt-2 flex items-end justify-between">
+            <span className="text-2xl font-bold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+              {analytics.total}
+            </span>
+            <BellRing className="h-6 w-6 text-[#3A7FFF]" aria-hidden="true" />
+          </div>
+          <p className="mt-1 text-xs text-slate-500">{analytics.unread} unread • {analytics.urgent} urgent</p>
+        </article>
+        <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <p className="text-xs uppercase tracking-wide text-slate-500" style={{ fontFamily: 'Lato, sans-serif' }}>
+            Open rate
+          </p>
+          <div className="mt-2 flex items-end justify-between">
+            <span className="text-2xl font-bold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+              {(analytics.openRate * 100).toFixed(0)}%
+            </span>
+            <MailOpen className="h-6 w-6 text-[#2D9B66]" aria-hidden="true" />
+          </div>
+          <p className="mt-1 text-xs text-slate-500">{analytics.read} viewed to date</p>
+        </article>
+        <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <p className="text-xs uppercase tracking-wide text-slate-500" style={{ fontFamily: 'Lato, sans-serif' }}>
+            Click engagement
+          </p>
+          <div className="mt-2 flex items-end justify-between">
+            <span className="text-2xl font-bold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+              {(analytics.clickRate * 100).toFixed(0)}%
+            </span>
+            <Megaphone className="h-6 w-6 text-[#FF8895]" aria-hidden="true" />
+          </div>
+          <p className="mt-1 text-xs text-slate-500">Tracked via in-app actions</p>
+        </article>
+        <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <p className="text-xs uppercase tracking-wide text-slate-500" style={{ fontFamily: 'Lato, sans-serif' }}>
+            Archived items
+          </p>
+          <div className="mt-2 flex items-end justify-between">
+            <span className="text-2xl font-bold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+              {analytics.archived}
+            </span>
+            <Archive className="h-6 w-6 text-slate-500" aria-hidden="true" />
+          </div>
+          <p className="mt-1 text-xs text-slate-500">Keep your feed organized by archiving completed items.</p>
+        </article>
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap gap-3">
+            <label className="flex items-center space-x-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm">
+              <ListFilter className="h-4 w-4 text-slate-500" aria-hidden="true" />
+              <select
+                value={typeFilter}
+                onChange={(event) => {
+                  setTypeFilter(event.target.value as typeof typeFilter);
+                  setPage(1);
+                }}
+                className="bg-transparent text-sm text-slate-700 focus:outline-none"
+              >
+                <option value="all">All types</option>
+                {Object.entries(typeLabelMap).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex items-center space-x-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm">
+              <Filter className="h-4 w-4 text-slate-500" aria-hidden="true" />
+              <select
+                value={categoryFilter}
+                onChange={(event) => {
+                  setCategoryFilter(event.target.value as typeof categoryFilter);
+                  setPage(1);
+                }}
+                className="bg-transparent text-sm text-slate-700 focus:outline-none"
+              >
+                <option value="all">All categories</option>
+                <option value="alert">Alerts</option>
+                <option value="announcement">Announcements</option>
+                <option value="reminder">Reminders</option>
+                <option value="celebration">Celebrations</option>
+                <option value="update">Updates</option>
+              </select>
+            </label>
+            <label className="flex items-center space-x-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm">
+              <BellRing className="h-4 w-4 text-slate-500" aria-hidden="true" />
+              <select
+                value={sortOption}
+                onChange={(event) => {
+                  setSortOption(event.target.value as typeof sortOption);
+                  setPage(1);
+                }}
+                className="bg-transparent text-sm text-slate-700 focus:outline-none"
+              >
+                <option value="newest">Newest first</option>
+                <option value="oldest">Oldest first</option>
+                <option value="priority">Priority</option>
+              </select>
+            </label>
+          </div>
+          <button
+            onClick={() => {
+              setShowArchived((prev) => !prev);
+              setPage(1);
+            }}
+            className={cn(
+              'inline-flex items-center space-x-2 rounded-full px-4 py-2 text-sm font-semibold transition',
+              showArchived
+                ? 'bg-slate-900 text-white shadow-sm'
+                : 'border border-slate-200 bg-white text-slate-700 shadow-sm'
+            )}
+          >
+            <Archive className="h-4 w-4" aria-hidden="true" />
+            <span>{showArchived ? 'Showing archived' : 'View archived'}</span>
+          </button>
+        </div>
+
+        <div className="mt-6 space-y-3">
+          {loading ? (
+            <div className="flex items-center justify-center rounded-xl border border-dashed border-slate-300 py-16 text-slate-500">
+              <Loader2 className="h-6 w-6 animate-spin" aria-hidden="true" />
+              <span className="ml-2 text-sm">Loading notifications…</span>
+            </div>
+          ) : pageItems.length === 0 ? (
+            <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-slate-50 py-16 text-center">
+              <Inbox className="h-10 w-10 text-slate-300" aria-hidden="true" />
+              <p className="mt-3 text-sm font-semibold text-slate-600">No notifications to show</p>
+              <p className="text-xs text-slate-500">Adjust filters or check back later for new updates.</p>
+            </div>
+          ) : (
+            pageItems.map((notification) => (
+              <article
+                key={notification.id}
+                className={cn(
+                  'flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-[#3A7FFF]/40 hover:shadow-lg dark:border-slate-700 dark:bg-slate-900 sm:flex-row sm:items-center',
+                  !notification.isRead && !notification.archived && 'bg-[#3A7FFF]/5'
+                )}
+              >
+                <div className="flex flex-1 flex-col gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className={cn('rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide', categoryColor(notification.category))}>
+                      {notification.category}
+                    </span>
+                    <span className="rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-700">
+                      {typeLabelMap[notification.type]}
+                    </span>
+                    <span className={cn('rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide', priorityColor(notification))}>
+                      {notification.priority}
+                    </span>
+                    {notification.recipientOrgId && (
+                      <span className="rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-600">
+                        Org: {notification.recipientOrgId}
+                      </span>
+                    )}
+                  </div>
+                  <h2 className="text-lg font-semibold text-slate-900" style={{ fontFamily: 'Montserrat, sans-serif' }}>
+                    {notification.title}
+                  </h2>
+                  <p className="text-sm text-slate-600" style={{ fontFamily: 'Lato, sans-serif' }}>
+                    {notification.message}
+                  </p>
+                  <div className="flex flex-wrap items-center gap-4 text-xs text-slate-500">
+                    <span className="inline-flex items-center gap-1">
+                      <AlertTriangle className="h-3.5 w-3.5 text-[#3A7FFF]" aria-hidden="true" />
+                      {formatRelativeTime(notification.createdAt)}
+                    </span>
+                    {notification.expiresAt && (
+                      <span>Expires {new Date(notification.expiresAt).toLocaleDateString()}</span>
+                    )}
+                    {notification.link && (
+                      <Link
+                        to={notification.link}
+                        onClick={() => markAsRead(notification.id)}
+                        className="inline-flex items-center gap-1 text-[#3A7FFF] hover:text-[#2D9B66]"
+                      >
+                        Open destination
+                      </Link>
+                    )}
+                  </div>
+                </div>
+                <div className="flex flex-col items-stretch gap-2 sm:min-w-[12rem]">
+                  {!notification.isRead ? (
+                    <button
+                      onClick={() => markAsRead(notification.id)}
+                      className="inline-flex items-center justify-center gap-2 rounded-full bg-[#2D9B66] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#1f8051]"
+                    >
+                      <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+                      Mark read
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => markAsUnread(notification.id)}
+                      className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-[#3A7FFF] hover:text-[#3A7FFF]"
+                    >
+                      <MailOpen className="h-4 w-4" aria-hidden="true" />
+                      Mark unread
+                    </button>
+                  )}
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => (notification.archived ? restore(notification.id) : archive(notification.id))}
+                      className={cn(
+                        'flex-1 rounded-full px-4 py-2 text-sm font-semibold transition',
+                        notification.archived
+                          ? 'border border-slate-300 text-slate-600 hover:border-[#3A7FFF] hover:text-[#3A7FFF]'
+                          : 'border border-slate-300 text-slate-600 hover:border-[#3A7FFF] hover:text-[#3A7FFF]'
+                      )}
+                    >
+                      {notification.archived ? 'Restore' : 'Archive'}
+                    </button>
+                    <button
+                      onClick={() => remove(notification.id)}
+                      className="rounded-full border border-[#D72638]/40 px-3 py-2 text-sm text-[#D72638] transition hover:bg-[#D72638] hover:text-white"
+                    >
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
+              </article>
+            ))
+          )}
+        </div>
+
+        {pageItems.length > 0 && (
+          <div className="mt-6 flex items-center justify-between">
+            <span className="text-xs text-slate-500">
+              Showing {(page - 1) * PAGE_SIZE + 1}–
+              {Math.min(page * PAGE_SIZE, filtered.length)} of {filtered.length}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => handlePageChange(page - 1)}
+                disabled={page === 1}
+                className="rounded-full border border-slate-200 px-3 py-1 text-sm text-slate-600 transition hover:border-[#3A7FFF] hover:text-[#3A7FFF] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Previous
+              </button>
+              <span className="text-xs font-semibold text-slate-600">
+                Page {page} of {totalPages}
+              </span>
+              <button
+                onClick={() => handlePageChange(page + 1)}
+                disabled={page === totalPages}
+                className="rounded-full border border-slate-200 px-3 py-1 text-sm text-slate-600 transition hover:border-[#3A7FFF] hover:text-[#3A7FFF] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default NotificationsHubPage;

--- a/src/services/notificationAnalyticsService.ts
+++ b/src/services/notificationAnalyticsService.ts
@@ -1,0 +1,121 @@
+import {
+  NotificationAnalytics,
+  NotificationEvent,
+  NotificationEventType,
+  NotificationRecord,
+} from '../types/notifications';
+
+const EVENT_STORAGE_KEY = 'huddle_notification_events_v1';
+
+const readEvents = (): NotificationEvent[] => {
+  try {
+    const raw = localStorage.getItem(EVENT_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as NotificationEvent[];
+  } catch (error) {
+    console.error('[NotificationAnalytics] Failed to read events', error);
+    return [];
+  }
+};
+
+const writeEvents = (events: NotificationEvent[]) => {
+  try {
+    localStorage.setItem(EVENT_STORAGE_KEY, JSON.stringify(events));
+  } catch (error) {
+    console.error('[NotificationAnalytics] Failed to persist events', error);
+  }
+};
+
+export const logNotificationEvent = (
+  notificationId: string,
+  type: NotificationEventType,
+  userId?: string | null,
+  metadata?: Record<string, unknown>
+) => {
+  const events = readEvents();
+  const event: NotificationEvent = {
+    id: `${notificationId}-${type}-${Date.now()}`,
+    notificationId,
+    type,
+    occurredAt: new Date().toISOString(),
+    userId,
+    metadata,
+  };
+  events.push(event);
+  writeEvents(events);
+  return event;
+};
+
+export const getNotificationEvents = () => readEvents();
+
+export const clearNotificationEvents = () => writeEvents([]);
+
+const initTypeMap = <T extends string>(keys: T[], fallback = 0) =>
+  keys.reduce<Record<T, number>>((acc, key) => {
+    acc[key] = fallback;
+    return acc;
+  }, {} as Record<T, number>);
+
+export const buildNotificationAnalytics = (
+  notifications: NotificationRecord[],
+  events: NotificationEvent[]
+): NotificationAnalytics => {
+  const total = notifications.length;
+  const read = notifications.filter((n) => n.isRead).length;
+  const unread = notifications.filter((n) => !n.isRead && !n.archived).length;
+  const archived = notifications.filter((n) => n.archived).length;
+  const urgent = notifications.filter((n) => n.priority === 'urgent' || n.priority === 'high').length;
+
+  const byType = notifications.reduce<Record<string, number>>((acc, note) => {
+    acc[note.type] = (acc[note.type] ?? 0) + 1;
+    return acc;
+  }, initTypeMap(['assignment', 'course_update', 'survey_reminder', 'completion', 'broadcast', 'system', 'message'] as const));
+
+  const byCategory = notifications.reduce<Record<string, number>>((acc, note) => {
+    acc[note.category] = (acc[note.category] ?? 0) + 1;
+    return acc;
+  }, initTypeMap(['alert', 'announcement', 'update', 'celebration', 'reminder'] as const));
+
+  const deliveredEvents = events.filter((event) => event.type === 'delivered');
+  const clickEvents = events.filter((event) => event.type === 'clicked');
+
+  const denominator = deliveredEvents.length || total || 1;
+  const openRate = total === 0 ? 0 : read / total;
+  const clickRate = clickEvents.length / denominator;
+
+  const engagementByOrgMap = notifications.reduce<Record<string, { sent: number; read: number }>>((acc, notification) => {
+    if (!notification.recipientOrgId) return acc;
+    const bucket = acc[notification.recipientOrgId] ?? { sent: 0, read: 0 };
+    bucket.sent += 1;
+    if (notification.isRead) bucket.read += 1;
+    acc[notification.recipientOrgId] = bucket;
+    return acc;
+  }, {});
+
+  const engagementByOrg = Object.entries(engagementByOrgMap).map(([orgId, stats]) => ({
+    orgId,
+    ...stats,
+  }));
+
+  return {
+    total,
+    read,
+    unread,
+    archived,
+    urgent,
+    byType: byType as NotificationAnalytics['byType'],
+    byCategory: byCategory as NotificationAnalytics['byCategory'],
+    openRate,
+    clickRate,
+    engagementByOrg,
+  };
+};
+
+export default {
+  logNotificationEvent,
+  getNotificationEvents,
+  clearNotificationEvents,
+  buildNotificationAnalytics,
+};

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,38 +1,308 @@
-export type Notification = {
-  id: string;
-  title: string;
-  body?: string;
-  orgId?: string;
-  userId?: string;
-  createdAt: string;
-  read?: boolean;
+import { supabase } from '../lib/supabase';
+import {
+  NotificationFilterOptions,
+  NotificationInput,
+  NotificationRecord,
+} from '../types/notifications';
+
+const STORAGE_KEY = 'huddle_notification_center_v2';
+
+const isSupabaseConfigured = Boolean(
+  import.meta.env.VITE_SUPABASE_URL && import.meta.env.VITE_SUPABASE_ANON_KEY
+);
+
+const toNotificationRecord = (payload: any): NotificationRecord => ({
+  id: payload.id ?? `note-${Date.now()}`,
+  type: payload.type ?? 'system',
+  title: payload.title ?? 'Notification',
+  message: payload.message ?? '',
+  link: payload.link ?? null,
+  actionLabel: payload.action_label ?? payload.actionLabel ?? null,
+  recipientUserId: payload.recipient_user_id ?? payload.recipientUserId ?? null,
+  recipientOrgId: payload.recipient_org_id ?? payload.recipientOrgId ?? null,
+  isRead: Boolean(payload.is_read ?? payload.isRead ?? false),
+  createdAt: payload.created_at ?? payload.createdAt ?? new Date().toISOString(),
+  expiresAt: payload.expires_at ?? payload.expiresAt ?? null,
+  priority: payload.priority ?? 'medium',
+  senderId: payload.sender_id ?? payload.senderId ?? null,
+  category: payload.category ?? 'update',
+  metadata: payload.metadata ?? null,
+  archived: payload.archived ?? false,
+});
+
+const readLocalCache = (): NotificationRecord[] => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map(toNotificationRecord);
+  } catch (error) {
+    console.error('[NotificationService] Failed to read cache', error);
+    return [];
+  }
 };
 
-const KEY = 'huddle_notifications_v1';
-
-const read = (): Notification[] => {
-  const raw = localStorage.getItem(KEY);
-  if (!raw) return [];
-  try { return JSON.parse(raw) as Notification[]; } catch { return []; }
+const writeLocalCache = (items: NotificationRecord[]) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch (error) {
+    console.error('[NotificationService] Failed to persist cache', error);
+  }
 };
 
-const write = (items: Notification[]) => localStorage.setItem(KEY, JSON.stringify(items));
-
-export const listNotifications = async (opts?: { orgId?: string; userId?: string }) => {
-  let items = read();
-  if (opts?.orgId) items = items.filter(i => i.orgId === opts.orgId || !i.orgId);
-  if (opts?.userId) items = items.filter(i => i.userId === opts.userId || !i.userId);
-  return items.slice().sort((a,b) => +new Date(b.createdAt) - +new Date(a.createdAt));
+export const loadNotificationCache = (): NotificationRecord[] => {
+  return readLocalCache();
 };
 
-export const addNotification = async (n: Omit<Notification,'id'|'createdAt'>) => {
-  const items = read();
-  const note: Notification = { id: `note-${Date.now()}`, createdAt: new Date().toISOString(), ...n };
-  items.push(note);
-  write(items);
-  return note;
+const filterNotifications = (
+  notifications: NotificationRecord[],
+  opts?: NotificationFilterOptions
+) => {
+  if (!opts) return notifications;
+  return notifications.filter((notification) => {
+    const matchesUser = opts.userId
+      ? !notification.recipientUserId || notification.recipientUserId === opts.userId
+      : true;
+    const matchesOrg = opts.orgId
+      ? !notification.recipientOrgId || notification.recipientOrgId === opts.orgId
+      : true;
+    const matchesArchived = opts.includeArchived ? true : !notification.archived;
+
+    return matchesUser && matchesOrg && matchesArchived;
+  });
 };
 
-export const clearNotifications = async () => { write([]); };
+export const fetchNotifications = async (
+  opts?: NotificationFilterOptions
+): Promise<NotificationRecord[]> => {
+  if (isSupabaseConfigured) {
+    try {
+      const query = supabase
+        .from('notifications')
+        .select('*')
+        .order('created_at', { ascending: false });
 
-export default { listNotifications, addNotification, clearNotifications };
+      const filters: string[] = [];
+      if (opts?.userId) {
+        filters.push(`recipient_user_id.eq.${opts.userId}`);
+      }
+      if (opts?.orgId) {
+        filters.push(`recipient_org_id.eq.${opts.orgId}`);
+      }
+
+      if (filters.length > 0) {
+        query.or(filters.join(','));
+      }
+
+      if (opts?.limit) {
+        query.limit(opts.limit);
+      }
+
+      const { data, error } = await query;
+      if (error) throw error;
+      if (!data) return [];
+
+      return data
+        .map(toNotificationRecord)
+        .filter((item) => (opts?.includeArchived ? true : !item.archived));
+    } catch (error) {
+      console.warn('[NotificationService] Falling back to cache', error);
+    }
+  }
+
+  const cache = readLocalCache();
+  const filtered = filterNotifications(cache, opts);
+  const sorted = filtered.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+  return opts?.limit ? sorted.slice(0, opts.limit) : sorted;
+};
+
+export const createNotification = async (
+  input: NotificationInput
+): Promise<NotificationRecord> => {
+  const payload: NotificationRecord = {
+    id: input.id ?? `note-${Date.now()}`,
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    isRead: input.isRead ?? false,
+    archived: input.archived ?? false,
+    type: input.type ?? 'system',
+    title: input.title ?? 'Notification',
+    message: input.message ?? '',
+    link: input.link ?? null,
+    actionLabel: input.actionLabel ?? null,
+    recipientUserId: input.recipientUserId ?? null,
+    recipientOrgId: input.recipientOrgId ?? null,
+    expiresAt: input.expiresAt ?? null,
+    priority: input.priority ?? 'medium',
+    senderId: input.senderId ?? null,
+    category: input.category ?? 'update',
+    metadata: input.metadata ?? null,
+  };
+
+  if (isSupabaseConfigured) {
+    try {
+      const { data, error } = await supabase
+        .from('notifications')
+        .insert({
+          id: payload.id,
+          type: payload.type,
+          title: payload.title,
+          message: payload.message,
+          link: payload.link,
+          action_label: payload.actionLabel,
+          recipient_user_id: payload.recipientUserId,
+          recipient_org_id: payload.recipientOrgId,
+          is_read: payload.isRead,
+          created_at: payload.createdAt,
+          expires_at: payload.expiresAt,
+          priority: payload.priority,
+          sender_id: payload.senderId,
+          category: payload.category,
+          metadata: payload.metadata,
+          archived: payload.archived,
+        })
+        .select()
+        .single();
+
+      if (error) throw error;
+      if (data) {
+        const record = toNotificationRecord(data);
+        if (!isSupabaseConfigured) {
+          // Should not happen but keeps types happy
+          return record;
+        }
+        return record;
+      }
+    } catch (error) {
+      console.warn('[NotificationService] Failed to create via Supabase', error);
+    }
+  }
+
+  const cache = readLocalCache();
+  cache.push(payload);
+  writeLocalCache(cache);
+  return payload;
+};
+
+const updateCacheItem = (id: string, updater: (item: NotificationRecord) => NotificationRecord) => {
+  const cache = readLocalCache();
+  const updated = cache.map((item) => (item.id === id ? updater(item) : item));
+  writeLocalCache(updated);
+  return updated.find((item) => item.id === id);
+};
+
+export const markNotificationRead = async (id: string, isRead = true) => {
+  if (isSupabaseConfigured) {
+    try {
+      const { error } = await supabase
+        .from('notifications')
+        .update({ is_read: isRead })
+        .eq('id', id);
+      if (error) throw error;
+    } catch (error) {
+      console.warn('[NotificationService] Failed to update read status', error);
+    }
+  }
+
+  return updateCacheItem(id, (item) => ({ ...item, isRead }));
+};
+
+export const archiveNotification = async (id: string, archived = true) => {
+  if (isSupabaseConfigured) {
+    try {
+      const { error } = await supabase
+        .from('notifications')
+        .update({ archived })
+        .eq('id', id);
+      if (error) throw error;
+    } catch (error) {
+      console.warn('[NotificationService] Failed to archive notification', error);
+    }
+  }
+
+  return updateCacheItem(id, (item) => ({ ...item, archived }));
+};
+
+export const deleteNotification = async (id: string) => {
+  if (isSupabaseConfigured) {
+    try {
+      const { error } = await supabase.from('notifications').delete().eq('id', id);
+      if (error) throw error;
+    } catch (error) {
+      console.warn('[NotificationService] Failed to delete notification', error);
+    }
+  }
+
+  const cache = readLocalCache();
+  const filtered = cache.filter((item) => item.id !== id);
+  writeLocalCache(filtered);
+};
+
+export const markAllNotificationsRead = async (opts?: NotificationFilterOptions) => {
+  if (isSupabaseConfigured) {
+    try {
+      const query = supabase.from('notifications').update({ is_read: true }).eq('is_read', false);
+      if (opts?.userId) {
+        query.eq('recipient_user_id', opts.userId);
+      }
+      if (opts?.orgId) {
+        query.eq('recipient_org_id', opts.orgId);
+      }
+      const { error } = await query;
+      if (error) throw error;
+    } catch (error) {
+      console.warn('[NotificationService] Failed to mark all read via Supabase', error);
+    }
+  }
+
+  const cache = readLocalCache().map((item) => {
+    const inScope = (!opts?.userId || item.recipientUserId === opts.userId || !item.recipientUserId)
+      && (!opts?.orgId || item.recipientOrgId === opts.orgId || !item.recipientOrgId);
+    if (!inScope) return item;
+    return { ...item, isRead: true };
+  });
+  writeLocalCache(cache);
+};
+
+export const subscribeToNotifications = (
+  callback: (event: 'INSERT' | 'UPDATE' | 'DELETE', record: NotificationRecord) => void
+) => {
+  if (!isSupabaseConfigured || !supabase?.channel) {
+    return () => {};
+  }
+
+  const channel = supabase
+    .channel('notifications_feed')
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'notifications' }, (payload: any) => {
+      const data = payload.new ?? payload.old;
+      if (!data) return;
+      callback(payload.eventType, toNotificationRecord(data));
+    })
+    .subscribe();
+
+  return () => {
+    try {
+      supabase.removeChannel(channel);
+    } catch (error) {
+      console.warn('[NotificationService] Failed to unsubscribe', error);
+    }
+  };
+};
+
+export const persistNotificationCache = (notifications: NotificationRecord[]) => {
+  writeLocalCache(notifications);
+};
+
+export default {
+  fetchNotifications,
+  createNotification,
+  markNotificationRead,
+  markAllNotificationsRead,
+  archiveNotification,
+  deleteNotification,
+  subscribeToNotifications,
+  persistNotificationCache,
+  loadNotificationCache,
+};

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,0 +1,96 @@
+export type NotificationType =
+  | 'assignment'
+  | 'course_update'
+  | 'survey_reminder'
+  | 'completion'
+  | 'broadcast'
+  | 'system'
+  | 'message';
+
+export type NotificationCategory = 'alert' | 'announcement' | 'update' | 'celebration' | 'reminder';
+
+export type NotificationPriority = 'low' | 'medium' | 'high' | 'urgent';
+
+export interface NotificationRecord {
+  id: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  link?: string | null;
+  actionLabel?: string | null;
+  recipientUserId?: string | null;
+  recipientOrgId?: string | null;
+  isRead: boolean;
+  createdAt: string;
+  expiresAt?: string | null;
+  priority: NotificationPriority;
+  senderId?: string | null;
+  category: NotificationCategory;
+  metadata?: Record<string, unknown> | null;
+  archived?: boolean;
+}
+
+export interface NotificationInput extends Partial<Omit<NotificationRecord, 'id' | 'createdAt' | 'isRead'>> {
+  id?: string;
+  createdAt?: string;
+  isRead?: boolean;
+}
+
+export interface NotificationFilterOptions {
+  userId?: string;
+  orgId?: string;
+  limit?: number;
+  includeArchived?: boolean;
+}
+
+export interface NotificationPreferences {
+  assignments: boolean;
+  courseUpdates: boolean;
+  surveyReminders: boolean;
+  completionCelebrations: boolean;
+  announcements: boolean;
+  systemUpdates: boolean;
+  digestFrequency: 'daily' | 'weekly' | 'off';
+  allowPush: boolean;
+  emailSummary: boolean;
+}
+
+export type NotificationEventType = 'delivered' | 'read' | 'clicked' | 'archived' | 'deleted';
+
+export interface NotificationEvent {
+  id: string;
+  notificationId: string;
+  type: NotificationEventType;
+  occurredAt: string;
+  userId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface NotificationAnalytics {
+  total: number;
+  unread: number;
+  read: number;
+  archived: number;
+  urgent: number;
+  byType: Record<NotificationType, number>;
+  byCategory: Record<NotificationCategory, number>;
+  openRate: number;
+  clickRate: number;
+  engagementByOrg: Array<{
+    orgId: string;
+    sent: number;
+    read: number;
+  }>;
+}
+
+export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
+  assignments: true,
+  courseUpdates: true,
+  surveyReminders: true,
+  completionCelebrations: true,
+  announcements: true,
+  systemUpdates: true,
+  digestFrequency: 'daily',
+  allowPush: false,
+  emailSummary: true,
+};

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,4 @@
+export const cn = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(' ');
+
+export default cn;


### PR DESCRIPTION
## Summary
- add a notification data model, analytics logging, and provider to sync alerts across portals in real time
- introduce shared notification UI components including the bell dropdown, in-app banners, and learner preference form
- build a dedicated notifications hub route and an admin broadcast center with templates, scheduling, and engagement metrics

## Testing
- npm run lint *(fails: existing lint issues in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68f04c54ee8c832c98725857b4cdd630